### PR TITLE
fix: no translation for some sentences

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -49,7 +49,7 @@ function translate(query, completion) {
     if (isChatGPTModel) {
         body.messages = [
             { role: "system", content: prompt },
-            { role: "user", content: query.text },
+            { role: "user", content: `"${query.text}"` },
         ];
     } else {
         body.prompt = `${prompt}:\n\n"${query.text}" =>`;
@@ -95,14 +95,14 @@ function translate(query, completion) {
             } else {
                 targetTxt = choices[0].text.trim();
             }
-            if (!isChatGPTModel) {
-                if (targetTxt.startsWith('"')) {
-                    targetTxt = targetTxt.slice(1);
-                }
-                if (targetTxt.endsWith('"')) {
-                    targetTxt = targetTxt.slice(0, -1);
-                }
+            
+            if (targetTxt.startsWith('"')) {
+                targetTxt = targetTxt.slice(1);
             }
+            if (targetTxt.endsWith('"')) {
+                targetTxt = targetTxt.slice(0, -1);
+            }
+            
             completion({
                 result: {
                     from: query.detectFrom,


### PR DESCRIPTION
Use quotation marks to highlight the content that needs to be translated to fix the problem of missing translations for some sentences like the following.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/18393754/222747659-02dda669-4d99-46ed-8f7c-086ea9e377d9.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/18393754/222747902-af256aa5-55c5-4129-9779-ae9a2c91e4c2.png">
