### PR TITLE
feat: add thinking mode toggle for reasoning models

### DIFF
--- a/public/info.json
+++ b/public/info.json
@@ -63,24 +63,24 @@
           "value": "custom"
         },
         {
+          "title": "GPT 5.2",
+          "value": "gpt-5.2"
+        },
+        {
+          "title": "GPT 5.1",
+          "value": "gpt-5.1"
+        },
+        {
           "title": "GPT-5 mini",
           "value": "gpt-5-mini"
         },
         {
-          "title": "GPT-5 nano",
-          "value": "gpt-5-nano"
-        },
-        {
-          "title": "GPT-4.1 mini",
-          "value": "gpt-4.1-mini"
+          "title": "Gemini 3 Flash",
+          "value": "gemini-3-flash"
         },
         {
           "title": "Gemini 2.5 Flash",
           "value": "gemini-2.5-flash"
-        },
-        {
-          "title": "Gemini 2.5 Flash-Lite",
-          "value": "gemini-2.5-flash-lite"
         }
       ],
       "title": "模型",
@@ -90,7 +90,7 @@
       "desc": "可选项。当 Model 选择 Custom 时，此项为必填项。请填写有效的模型名称",
       "identifier": "customModel",
       "textConfig": {
-        "placeholderText": "gpt-5-nano",
+        "placeholderText": "gpt-5.2",
         "type": "visible"
       },
       "title": "自定义模型",
@@ -139,8 +139,25 @@
       "type": "menu"
     },
     {
+      "defaultValue": "disable",
+      "desc": "仅部分模型支持通过此设置控制深度思考能力的启用状态。禁用可减少延迟和 token 消耗，适合翻译场景",
+      "identifier": "thinkingMode",
+      "menuValues": [
+        {
+          "title": "Disable",
+          "value": "disable"
+        },
+        {
+          "title": "Enable",
+          "value": "enable"
+        }
+      ],
+      "title": "深度思考",
+      "type": "menu"
+    },
+    {
       "defaultValue": "0.2",
-      "desc": "可选项。温度值越高，生成的文本越随机。默认值为 0.2。GPT-5 系列模型必须设置为 1",
+      "desc": "可选项。温度值越高，生成的文本越随机。默认值为 0.2",
       "identifier": "temperature",
       "textConfig": {
         "placeholderText": "0.2",
@@ -151,5 +168,5 @@
     }
   ],
   "summary": "AI powered translator",
-  "version": "4.0.3"
+  "version": "4.1.0"
 }

--- a/src/adapter/base.ts
+++ b/src/adapter/base.ts
@@ -27,6 +27,10 @@ export abstract class BaseAdapter implements ServiceAdapter {
     return $option.model === 'custom' ? $option.customModel : $option.model;
   }
 
+  protected isThinkingModeEnabled(): boolean {
+    return $option.thinkingMode === 'enable';
+  }
+
   abstract buildHeaders(apiKey: string): Record<string, string>;
 
   abstract buildRequestBody(query: TextTranslateQuery): Record<string, unknown>;

--- a/src/adapter/gemini.ts
+++ b/src/adapter/gemini.ts
@@ -59,6 +59,20 @@ export class GeminiAdapter extends BaseAdapter {
     const { generatedSystemPrompt, generatedUserPrompt } =
       generatePrompts(query);
 
+    const generationConfig: Record<string, unknown> = {
+      temperature: this.getTemperature(),
+    };
+
+    if (!this.isThinkingModeEnabled()) {
+      const model = this.getModel();
+      // Gemini 3 series uses thinkingLevel, Gemini 2.5 series uses thinkingBudget
+      if (model.includes('gemini-3')) {
+        generationConfig.thinkingConfig = { thinkingLevel: 'minimal' };
+      } else {
+        generationConfig.thinkingConfig = { thinkingBudget: 0 };
+      }
+    }
+
     return {
       system_instruction: {
         parts: {
@@ -70,12 +84,7 @@ export class GeminiAdapter extends BaseAdapter {
           text: generatedUserPrompt,
         },
       },
-      generationConfig: {
-        temperature: this.getTemperature(),
-        topK: 40,
-        topP: 0.95,
-        maxOutputTokens: 8192,
-      },
+      generationConfig,
     };
   }
 

--- a/src/adapter/openai.ts
+++ b/src/adapter/openai.ts
@@ -99,13 +99,26 @@ export class OpenAiAdapter extends BaseAdapter {
       '\n\nIMPORTANT: Output the translation directly without any quotation marks or special characters wrapping. Do not add quotes like 『』「」"" around the result.';
     systemPrompt += formattingInstructions;
 
-    return {
-      model: this.getModel(),
-      temperature: this.getTemperature(),
+    const model = this.getModel();
+    const body: Record<string, unknown> = {
+      model,
       stream: this.isStreamEnabled(),
       instructions: systemPrompt,
       input: userPrompt,
     };
+
+    // GPT-5 series models don't support temperature
+    if (!model.includes('gpt-5-')) {
+      body.temperature = this.getTemperature();
+    }
+
+    if (!this.isThinkingModeEnabled()) {
+      // GPT-5 series supports 'minimal', GPT-5.1/5.2 series supports 'none'
+      const effort = model.includes('gpt-5-') ? 'minimal' : 'none';
+      body.reasoning = { effort };
+    }
+
+    return body;
   }
 
   public parseResponse(


### PR DESCRIPTION
## Summary

- Add a "深度思考" (Deep Thinking) configuration option to control reasoning capabilities for models that support it
- Default is disabled since translation tasks don't require complex reasoning, reducing latency and token consumption
- Auto-skip temperature parameter for GPT-5 series models (not supported)
- Remove hardcoded generationConfig values for Gemini (use API defaults)
- Update model list with GPT-5.1, GPT-5.2, Gemini 3 Flash
- Bump version to 4.1.0

### Thinking mode implementation by provider:

| Provider | Model | Parameter |
|----------|-------|-----------|
| OpenAI | GPT-5 series | `reasoning.effort='minimal'` |
| OpenAI | GPT-5.1/5.2 series | `reasoning.effort='none'` |
| Gemini | Gemini 3 series | `thinkingConfig.thinkingLevel='minimal'` |
| Gemini | Gemini 2.5 series | `thinkingConfig.thinkingBudget=0` |

## Test plan

- [x] Test with GPT-5-mini model (should use `reasoning.effort='minimal'`, no temperature)
- [x] Test with GPT-5.1 model (should use `reasoning.effort='none'`, with temperature)
- [x] Test with Gemini 2.5 Flash (should use `thinkingBudget=0`)
- [x] Test with Gemini 3 Flash (should use `thinkingLevel='minimal'`)
- [x] Toggle "深度思考" to Enable and verify reasoning is used

## Summary by Sourcery

Add a configurable thinking mode toggle and wire it into OpenAI GPT-5* and Gemini adapters while simplifying Gemini generation configuration.

New Features:
- Introduce a thinking mode option that can be toggled via configuration and consumed by all adapters.

Enhancements:
- Apply provider-specific minimal reasoning settings for GPT-5* and Gemini models when thinking mode is disabled.
- Remove hardcoded Gemini generation parameters to rely primarily on API defaults while still honoring temperature.