### PR TITLE
feat: add MiniMax-M3 model support

### DIFF
--- a/docs/configuration_manual_CN.md
+++ b/docs/configuration_manual_CN.md
@@ -16,7 +16,7 @@
 
   - Google Gemini：使用 [Google Gemini](https://ai.google.dev/gemini-api/docs) 服务
 
-  - MiniMax：使用 [MiniMax](https://platform.minimax.io/) 服务，支持 MiniMax-M2.7 和 MiniMax-M2.7-highspeed 模型
+  - MiniMax：使用 [MiniMax](https://platform.minimax.io/) 服务，支持 MiniMax-M3、MiniMax-M2.7 和 MiniMax-M2.7-highspeed 模型
 
 
 ### API Base URL

--- a/docs/configuration_manual_EN.md
+++ b/docs/configuration_manual_EN.md
@@ -16,7 +16,7 @@
 
   - Google Gemini: Use [Google Gemini](https://ai.google.dev/gemini-api/docs) service
 
-  - MiniMax: Use [MiniMax](https://platform.minimax.io/) service, supports MiniMax-M2.7 and MiniMax-M2.7-highspeed models
+  - MiniMax: Use [MiniMax](https://platform.minimax.io/) service, supports MiniMax-M3, MiniMax-M2.7 and MiniMax-M2.7-highspeed models
 
 ### API Base URL
 

--- a/public/info.json
+++ b/public/info.json
@@ -97,6 +97,10 @@
           "value": "gemini-2.5-flash"
         },
         {
+          "title": "MiniMax-M3",
+          "value": "MiniMax-M3"
+        },
+        {
           "title": "MiniMax-M2.7",
           "value": "MiniMax-M2.7"
         },

--- a/src/adapter/__tests__/minimax.integration.test.ts
+++ b/src/adapter/__tests__/minimax.integration.test.ts
@@ -31,7 +31,7 @@ describe('MiniMax API integration', { timeout: 30000 }, () => {
             Authorization: `Bearer ${MINIMAX_API_KEY}`,
           },
           body: JSON.stringify({
-            model: 'MiniMax-M2.7',
+            model: 'MiniMax-M3',
             messages: [
               {
                 role: 'system',
@@ -136,7 +136,7 @@ describe('MiniMax API integration', { timeout: 30000 }, () => {
             Authorization: `Bearer ${MINIMAX_API_KEY}`,
           },
           body: JSON.stringify({
-            model: 'MiniMax-M2.7',
+            model: 'MiniMax-M3',
             messages: [
               { role: 'user', content: "Test connectivity. Reply with 'OK'." },
             ],

--- a/src/adapter/__tests__/minimax.test.ts
+++ b/src/adapter/__tests__/minimax.test.ts
@@ -64,7 +64,7 @@ describe('MiniMaxAdapter', () => {
   describe('temperature clamping', () => {
     it('should clamp temperature 0 to 0.01', () => {
       mockOption.temperature = '0';
-      mockOption.model = 'MiniMax-M2.7';
+      mockOption.model = 'MiniMax-M3';
       const adapter = new MiniMaxAdapter();
       const body = adapter.buildRequestBody({
         text: 'hello',
@@ -76,7 +76,7 @@ describe('MiniMaxAdapter', () => {
 
     it('should clamp negative temperature to 0.01', () => {
       mockOption.temperature = '-0.5';
-      mockOption.model = 'MiniMax-M2.7';
+      mockOption.model = 'MiniMax-M3';
       const adapter = new MiniMaxAdapter();
       const body = adapter.buildRequestBody({
         text: 'hello',
@@ -88,7 +88,7 @@ describe('MiniMaxAdapter', () => {
 
     it('should clamp temperature above 1 to 1.0', () => {
       mockOption.temperature = '1.5';
-      mockOption.model = 'MiniMax-M2.7';
+      mockOption.model = 'MiniMax-M3';
       const adapter = new MiniMaxAdapter();
       const body = adapter.buildRequestBody({
         text: 'hello',
@@ -100,7 +100,7 @@ describe('MiniMaxAdapter', () => {
 
     it('should keep valid temperature unchanged', () => {
       mockOption.temperature = '0.5';
-      mockOption.model = 'MiniMax-M2.7';
+      mockOption.model = 'MiniMax-M3';
       const adapter = new MiniMaxAdapter();
       const body = adapter.buildRequestBody({
         text: 'hello',
@@ -122,7 +122,7 @@ describe('MiniMaxAdapter', () => {
 
   describe('buildRequestBody', () => {
     it('should build Chat Completions API request body', () => {
-      mockOption.model = 'MiniMax-M2.7';
+      mockOption.model = 'MiniMax-M3';
       mockOption.temperature = '0.2';
       mockOption.stream = 'enable';
       const adapter = new MiniMaxAdapter();
@@ -132,7 +132,7 @@ describe('MiniMaxAdapter', () => {
         detectTo: 'zh-Hans',
       } as any);
 
-      expect(body.model).toBe('MiniMax-M2.7');
+      expect(body.model).toBe('MiniMax-M3');
       expect(body.stream).toBe(true);
       expect(body.messages).toBeDefined();
       expect(Array.isArray(body.messages)).toBe(true);
@@ -221,7 +221,7 @@ describe('MiniMaxAdapter', () => {
 
   describe('Chat Completions API format', () => {
     it('should always use Chat Completions API format by default', () => {
-      mockOption.model = 'MiniMax-M2.7';
+      mockOption.model = 'MiniMax-M3';
       mockOption.temperature = '0.5';
       const adapter = new MiniMaxAdapter();
       const body = adapter.buildRequestBody({
@@ -285,7 +285,7 @@ describe('MiniMaxAdapter integration', () => {
   });
 
   it('should build correct full request for translation', () => {
-    mockOption.model = 'MiniMax-M2.7';
+    mockOption.model = 'MiniMax-M3';
     mockOption.temperature = '0.2';
     mockOption.stream = 'disable';
 
@@ -300,7 +300,7 @@ describe('MiniMaxAdapter integration', () => {
 
     expect(url).toBe('https://api.minimax.io/v1/chat/completions');
     expect(headers.Authorization).toBe('Bearer test-key');
-    expect(body.model).toBe('MiniMax-M2.7');
+    expect(body.model).toBe('MiniMax-M3');
     expect(body.stream).toBe(false);
     expect(body.temperature).toBe(0.2);
   });

--- a/src/adapter/minimax.ts
+++ b/src/adapter/minimax.ts
@@ -60,7 +60,7 @@ export class MiniMaxAdapter extends OpenAiAdapter {
         url,
         header,
         body: {
-          model: 'MiniMax-M2.7',
+          model: 'MiniMax-M3',
           messages: [
             { role: 'user', content: "Test connectivity. Reply with 'OK'." },
           ],


### PR DESCRIPTION
## Summary

Adds MiniMax-M3, the latest MiniMax flagship model, to the provider's model menu while keeping the existing MiniMax-M2.7 and MiniMax-M2.7-highspeed options for users who prefer the previous generation.

## Changes

- `public/info.json`: add `MiniMax-M3` at the top of the MiniMax group in the model menu
- `src/adapter/minimax.ts`: switch the connectivity-test probe to `MiniMax-M3`
- `src/adapter/__tests__/minimax.test.ts` / `minimax.integration.test.ts`: update primary-path assertions to use `MiniMax-M3`; the M2.7-highspeed path is preserved to keep custom-model coverage
- `docs/configuration_manual_CN.md` / `configuration_manual_EN.md`: mention the new model alongside M2.7 / M2.7-highspeed

The MiniMax API URL, temperature clamping, request body shape, and TTS configuration are untouched.

## Test plan

- [x] `bun test src/adapter/__tests__/minimax.test.ts` — 19/19 pass
- [x] `bun run build` — succeeds
- [x] No regressions to other providers (only `minimax` files were modified)

## Summary by Sourcery

Add support for the MiniMax-M3 model and make it the default MiniMax option while retaining existing MiniMax models.

New Features:
- Expose the MiniMax-M3 model as a selectable option alongside existing MiniMax models.

Enhancements:
- Update MiniMax adapter connectivity checks and primary code paths to use MiniMax-M3 as the default model.

Documentation:
- Document MiniMax-M3 support in both English and Chinese configuration manuals.

Tests:
- Adjust MiniMax unit and integration tests to exercise MiniMax-M3 as the primary model path.