### PR TITLE
docs: add OrcaRouter as an OpenAI-compatible gateway example

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,6 +183,7 @@ The linked [Bob 1.8 plugin changes](https://bobtranslate.com/blog/2023-05-18-180
 - [OpenAI reasoning](https://developers.openai.com/api/docs/guides/reasoning)
 - [OpenAI Responses migration](https://developers.openai.com/api/docs/guides/migrate-to-responses)
 - [OpenRouter Quickstart](https://openrouter.ai/docs/quickstart)
+- [OrcaRouter](https://www.orcarouter.ai)
 - [Vercel AI Gateway Chat Completions](https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions/chat-completions)
 
 ## Rejected complexity

--- a/docs/configuration_manual_CN.md
+++ b/docs/configuration_manual_CN.md
@@ -50,6 +50,7 @@ API URL 可留空。留空时使用模型对应的官方地址。
 - MiniMax 中国区：`https://api.minimaxi.com/v1/chat/completions`
 - OpenAI 兼容 API：`https://gateway.example.com/v1/responses`
 - OpenRouter：`https://openrouter.ai/api/v1/chat/completions`
+- OrcaRouter：`https://api.orcarouter.ai/v1/chat/completions`
 - Vercel AI Gateway：`https://ai-gateway.vercel.sh/v1/chat/completions`
 
 填写 API URL 后，普通地址使用 Bearer Token。`*.openai.azure.com` 地址以及包含 `/openai/v1` 或 `/openai/deployments/` 的 Azure 路径会自动使用 `api-key` 请求头。

--- a/docs/configuration_manual_EN.md
+++ b/docs/configuration_manual_EN.md
@@ -50,6 +50,7 @@ Common examples:
 - MiniMax China: `https://api.minimaxi.com/v1/chat/completions`
 - OpenAI-compatible API: `https://gateway.example.com/v1/responses`
 - OpenRouter: `https://openrouter.ai/api/v1/chat/completions`
+- OrcaRouter: `https://api.orcarouter.ai/v1/chat/completions`
 - Vercel AI Gateway: `https://ai-gateway.vercel.sh/v1/chat/completions`
 
 With an API URL, ordinary hosts use a Bearer token. A `*.openai.azure.com` host or an Azure path containing `/openai/v1` or `/openai/deployments/` automatically uses the `api-key` header.


### PR DESCRIPTION
Add OrcaRouter as a named OpenAI-compatible gateway example in the docs

Mirrors the existing OpenRouter wiring: the plugin itself is a generic URL-based client (per AGENTS.md, individual services are named only when they provide a useful configuration example), and OrcaRouter is exactly such an example — it exposes Anthropic Claude models through a standard OpenAI-compatible `/v1/chat/completions` endpoint (`https://api.orcarouter.ai/v1/chat/completions`).

Changes:
- `docs/configuration_manual_EN.md`: added `OrcaRouter` to the "Common examples" list (sorted after OpenRouter, before Vercel)
- `docs/configuration_manual_CN.md`: same entry in the Chinese manual
- `docs/architecture.md`: added OrcaRouter to the "Provider sources" list

The endpoint was live-verified against `anthropic/claude-haiku-4.5` — it returns a standard `chat.completion`, so no provider-specific codec is needed (consistent with the architecture's "Rejected complexity" section).

[OrcaRouter](https://www.orcarouter.ai) is an AI gateway that routes requests to Claude and OpenAI models through one unified endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Summary by Sourcery

Documentation:
- Add OrcaRouter and its chat completions endpoint to the English and Chinese configuration manuals and provider source documentation.